### PR TITLE
Preventing automatic_throttle configuration

### DIFF
--- a/protocols/kad/src/bootstrap.rs
+++ b/protocols/kad/src/bootstrap.rs
@@ -4,6 +4,9 @@ use std::time::Duration;
 
 use futures_timer::Delay;
 
+/// Default value chosen at `<https://github.com/libp2p/rust-libp2p/pull/4838#discussion_r1490184754>`.
+pub(crate) const DEFAULT_AUTOMATIC_THROTTLE: Duration = Duration::from_millis(500);
+
 #[derive(Debug)]
 pub(crate) struct Status {
     /// If the user did not disable periodic bootstrap (by providing `None` for `periodic_interval`)
@@ -282,14 +285,13 @@ mod tests {
     async fn given_periodic_bootstrap_and_no_automatic_bootstrap_triggers_periodically() {
         let mut status = Status::new(Some(MS_100), None);
 
-        for _ in 0..5 {
-            let start = Instant::now();
-
+        let start = Instant::now();
+        for i in 1..6 {
             await_and_do_bootstrap(&mut status).await;
 
             let elapsed = Instant::now().duration_since(start);
 
-            assert!(elapsed > (MS_100 - Duration::from_millis(10))); // Subtract 10ms to avoid flakes.
+            assert!(elapsed > (i * MS_100 - Duration::from_millis(10))); // Subtract 10ms to avoid flakes.
         }
     }
 


### PR DESCRIPTION
## Description

Hi @PanGan21, as discussed [here with Thomas](https://github.com/libp2p/rust-libp2p/pull/4838#discussion_r1490184754), I'm making the `set_automatic_bootstrap_throttle` function private. I did not completely removed the function because it is useful to disable automatic bootstrap in unit tests.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
